### PR TITLE
Bug/26: voteRecord 이력이 존재하지 않으면 VOTE404 에러가 발생하는 문제점 해결

### DIFF
--- a/src/main/java/com/woori/codeshare/vote/service/VoteService.java
+++ b/src/main/java/com/woori/codeshare/vote/service/VoteService.java
@@ -14,6 +14,7 @@ import com.woori.codeshare.vote.exception.VoteException;
 import com.woori.codeshare.vote.repository.VoteRecordRepository;
 import com.woori.codeshare.vote.repository.VoteRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +25,7 @@ import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class VoteService {
 
     private final VoteRepository voteRepository;
@@ -110,15 +112,23 @@ public class VoteService {
      */
     @Transactional
     public VoteResponseDTO.VoteResultResponse getVoteResults(Long voteId) {
-        if (!voteRecordRepository.existsByVoteId(voteId)) {
+        // 먼저 vote 자체가 존재하는지 확인
+        if (!voteRepository.existsById(voteId)) {
             throw new VoteException(VoteErrorCode.VOTE_NOT_FOUND);
         }
 
+        // 투표 기록이 있는지 확인
+        if (!voteRecordRepository.existsByVoteId(voteId)) {
+            log.warn("[Vote] 투표 ID={}에 대한 기록이 없음. 기본값(0) 반환", voteId);
+            return createEmptyVoteResponse(voteId);
+        }
+
+        // 실제 투표 결과 조회
         List<Object[]> results = voteRecordRepository.countVotesByVoteId(voteId);
 
         Map<String, Integer> voteCounts = new HashMap<>();
         for (VoteType type : VoteType.values()) {
-            voteCounts.put(type.name(), 0);
+            voteCounts.put(type.name(), 0); // 기본값 0
         }
 
         for (Object[] row : results) {
@@ -132,6 +142,21 @@ public class VoteService {
                 .voteCounts(voteCounts)
                 .build();
     }
+
+    /**
+     * 투표 기록이 없는 경우 기본값을 반환하는 메서드
+     */
+    private VoteResponseDTO.VoteResultResponse createEmptyVoteResponse(Long voteId) {
+        Map<String, Integer> emptyVoteCounts = new HashMap<>();
+        for (VoteType type : VoteType.values()) {
+            emptyVoteCounts.put(type.name(), 0);
+        }
+        return VoteResponseDTO.VoteResultResponse.builder()
+                .voteId(voteId)
+                .voteCounts(emptyVoteCounts)
+                .build();
+    }
+
 
     /**
      * 특정 스냅샷의 모든 투표 결과 조회 로직


### PR DESCRIPTION
# 🐞 버그/에러 개요
<!-- 간단하게 한줄로 어떤 버그/에러인지 요약해서 적습니다 -->
DB에 vote_id는 있지만, 투표 진행하기 API에서 vote_id로 조회되지 않는 문제 발생

# 📝 상황 설명
### 📄  에러 대상
<!-- 에러가 어디서 났는지 적기 -->
ISSUE(#14 )

### 🕵🏻‍♀️    에러 상황
<!-- 에러가 어떻게 나고 있는지 상세하게 적기 (사진 있으면 첨부) -->
기존에 투표한 이력이 없으면 voteId가 조회되지 않는 문제가 있음

### ✅ Resolve TODO
<!-- 에러/버그 수정 항목 나열하기 (PR할 때에는 모두 체크되어야함) -->
- [x] 기존에 투표한 이력이 없어도 0, 0, 0 으로 조회될 수 있도록 수정
- [x] voteRecord 이력 확인 -> vote 객체 검증하도록 로직 수정
