### PR TITLE
Bug/33: 방 나가기 시 인원 수 업데이트가 안되는 에러 해결(방 입장 시 unique 값 응답하도록 수정)

### DIFF
--- a/src/main/java/com/woori/codeshare/socket/controller/dto/RoomSocketDTO.java
+++ b/src/main/java/com/woori/codeshare/socket/controller/dto/RoomSocketDTO.java
@@ -30,6 +30,7 @@ public class RoomSocketDTO {
     @AllArgsConstructor
     public static class RoomUserListResponse {
         private Long roomId;
+        private String nickname;
         private List<String> users;
         private int userCount;
         private String eventType; // JOIN or LEAVE

--- a/src/main/java/com/woori/codeshare/socket/service/RoomSocketService.java
+++ b/src/main/java/com/woori/codeshare/socket/service/RoomSocketService.java
@@ -39,7 +39,7 @@ public class RoomSocketService {
 
         log.info("[WebSocket] 방 입장: roomId={}, nickname={}", roomId, newNickname);
 
-        sendUpdatedUserList(roomId, users, "JOIN");
+        sendUpdatedUserList(roomId, newNickname, users, "JOIN");
     }
 
     /**
@@ -70,7 +70,7 @@ public class RoomSocketService {
                 log.info("[WebSocket] 방 삭제됨: roomId={}", roomId);
             }
 
-            sendUpdatedUserList(roomId, users, "LEAVE");
+            sendUpdatedUserList(roomId, nickname, users, "LEAVE");
         } else {
             log.warn("[WebSocket] 방 나가기 요청했지만 해당 닉네임이 존재하지 않음: roomId={}, nickname={}", roomId, nickname);
             messagingTemplate.convertAndSend("/topic/room/" + roomId + "/errors",
@@ -96,10 +96,11 @@ public class RoomSocketService {
     /**
      * 방 사용자 목록 업데이트 및 전송
      */
-    private void sendUpdatedUserList(Long roomId, List<String> users, String eventType) {
+    private void sendUpdatedUserList(Long roomId, String newnickname, List<String> users, String eventType) {
         RoomSocketDTO.RoomUserListResponse response =
                 RoomSocketDTO.RoomUserListResponse.builder()
                         .roomId(roomId)
+                        .nickname(newnickname)
                         .users(users)
                         .userCount(users.size())
                         .eventType(eventType)


### PR DESCRIPTION
# 🐞 버그/에러 개요
<!-- 간단하게 한줄로 어떤 버그/에러인지 요약해서 적습니다 -->
방 나가기 웹소켓 이벤트 발생 시, 인원 수 업데이트가 안되는 에러 처리

# 📝 상황 설명
### 📄  에러 대상
<!-- 에러가 어디서 났는지 적기 -->
Issue(#9 )

### 🕵🏻‍♀️ 에러 상황
<!-- 에러가 어떻게 나고 있는지 상세하게 적기 (사진 있으면 첨부) -->
방 입장시에는 인원 업데이트가 잘되는데, 방 나갈 시에 인원 업데이트가 되지 않는 문제 해결
> 클라이언트 단에서 방 나가기 요청 시 unique 값으로 웹소켓 이벤트 

### ✅ Resolve TODO
<!-- 에러/버그 수정 항목 나열하기 (PR할 때에는 모두 체크되어야함) -->
- [x] 방 입장 시, 응답 객체에 unique 값 포함해서 반환해주기
- [x] DOM 수정(브라우저 커서 아웃?)이 일어났을 때, 클라이언트 단에서 서버에 이벤트 발생 호출

### 📚 Remarks
<!-- 이슈 해결에 있어 비고사항이 있었다면 적기 -->