### PR TITLE
Ci/54: 운영서버 분리

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -3,7 +3,7 @@ name: Woori-Codeshare DEV API CI/CD
 on:
   push:
     branches:
-      - develop
+      - dev
 
 permissions:
   contents: read

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -1,94 +1,65 @@
 name: Woori-Codeshare DEV API CI/CD
 
 on:
-  pull_request:
+  push:
     branches:
-      - dev
-    types:
-      - closed
+      - develop
 
 permissions:
   contents: read
   actions: read
 
 jobs:
-  push-docker-image-to-ecr:
-    runs-on: ubuntu-latest
+  build-and-run-locally:
+    runs-on: self-hosted
+
     steps:
-      - name: Checkout code
+      - name: Runner 준비중...
+        run: echo "Runner is ready."
+
+      - name: 디스크 공간 확인 (정리 전)
+        run: df -h
+
+      - name: 코드 체크아웃
         uses: actions/checkout@v3
 
-      - name: Set up JDK 17
+      - name: Docker 시스템 정리
+        run: |
+          docker system prune -af
+          docker volume prune -f
+          docker builder prune -af
+
+      - name: 디스크 공간 확인 (정리 후)
+        run: df -h
+
+      - name: JDK 17 설정
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Set secret.yml file
+      - name: secret.yml 파일 설정
         run: |
           echo "$SECRET_YML_CONTENT" > ./src/main/resources/secret.yml
         env:
-          SECRET_YML_CONTENT: ${{ secrets.SECRET_YML }}
+          SECRET_YML_CONTENT: ${{ secrets.DEV_SECRET_YML }}
 
-      - name: Grant execute permission for gradlew
+      - name: Gradle 실행 권한 부여
         run: chmod +x ./gradlew
 
-      - name: Build with Gradle
+      - name: bootJar 빌드
         run: ./gradlew bootJar
-        env:
-          APP_VERSION: ${{ github.event.release.tag_name }}
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+      - name: 기존 컨테이너 및 이미지 삭제
+        run: |
+          docker stop server || true
+          docker rm server || true
+          docker rmi dev-server || true
 
-      - name: Log in to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+      - name: 도커 이미지 빌드
+        run: |
+          docker build -t dev-server .
 
-      - name: Build, tag, and push Container
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64
-          tags: |
-            ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.AWS_WCS_ECR_NAMESPACE }}/${{ secrets.AWS_WCS_ECR_REPO_NAME }}
-
-  deploy-to-ec2:
-    runs-on: ubuntu-latest
-    needs: push-docker-image-to-ecr
-    steps:
-      - name: Get Github Actions IP
-        id: ip
-        uses: haythem/public-ip@v1.3
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: SSH into EC2 and Deploy
-        uses: appleboy/ssh-action@v1.2.0
-        with:
-          host: ${{ secrets.AWS_WCS_BACKEND_INSTANCE_IP }}
-          username: ${{ secrets.AWS_WCS_BACKEND_INSTANCE_USER }}
-          key: ${{ secrets.AWS_WCS_BACKEND_INSTANCE_SSH_KEY }}
-          port: 22
-          script: |
-            sudo chmod 666 /var/run/docker.sock
-
-            docker stop server || true
-            docker rm server || true
-            docker rmi ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.ECR_REPO_NAME }}:latest || true
-
-            aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
-            docker pull ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.AWS_WCS_ECR_NAMESPACE }}/${{ secrets.AWS_WCS_ECR_REPO_NAME }}:latest
-            sudo docker run --name server -dp 8080:8080 \
-              -e APP_VERSION=${{ github.event.release.tag_name }} \
-              ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.AWS_WCS_ECR_NAMESPACE }}/${{ secrets.AWS_WCS_ECR_REPO_NAME }}:latest
+      - name: 도커 컨테이너 실행
+        run: |
+          docker run -d --name server -p 8080:8080 dev-server

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -1,0 +1,92 @@
+name: Woori-Codeshare DEV API CI/CD
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  push-docker-image-to-ecr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set secret.yml file
+        run: |
+          echo "$SECRET_YML_CONTENT" > ./src/main/resources/secret.yml
+        env:
+          SECRET_YML_CONTENT: ${{ secrets.PROD_SECRET_YML }}
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew bootJar
+        env:
+          APP_VERSION: ${{ github.event.release.tag_name }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Log in to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push Container
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.AWS_WCS_ECR_NAMESPACE }}/${{ secrets.AWS_WCS_ECR_REPO_NAME }}
+
+  deploy-to-ec2:
+    runs-on: ubuntu-latest
+    needs: push-docker-image-to-ecr
+    steps:
+      - name: Get Github Actions IP
+        id: ip
+        uses: haythem/public-ip@v1.3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: SSH into EC2 and Deploy
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.AWS_WCS_PROD_BACKEND_INSTANCE_IP }}
+          username: ${{ secrets.AWS_WCS_BACKEND_INSTANCE_USER }}
+          key: ${{ secrets.AWS_WCS_BACKEND_INSTANCE_SSH_KEY }}
+          port: 22
+          script: |
+            sudo chmod 666 /var/run/docker.sock
+
+            docker stop server || true
+            docker rm server || true
+            docker rmi ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.ECR_REPO_NAME }}:latest || true
+
+            aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
+            docker pull ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.AWS_WCS_ECR_NAMESPACE }}/${{ secrets.AWS_WCS_ECR_REPO_NAME }}:latest
+            sudo docker run --name server -dp 8080:8080 \
+              -e APP_VERSION=${{ github.event.release.tag_name }} \
+              ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.AWS_WCS_ECR_NAMESPACE }}/${{ secrets.AWS_WCS_ECR_REPO_NAME }}:latest


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
개발 서버와 운영 서버를 분리합니다.

## ⏳ 작업 내용
- [x] aws 인프라 추가 구축(prod 관련)
- [x] github actions runners 기반 dev ci/cd 배포 파이프라인 수정
- [x] prod용 deploy.yml 추가
- [x] 환경변수 분리

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
테스트 필요
